### PR TITLE
build(deps): ensure “Gallium” runtime & toolchain

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,11 @@
   "version": "1.1.3",
   "description": "Common Markdown table-related utilities",
   "packageManager": "npm",
-  "engines": { "node": "^16.13.0", "npm": "^8.1.0", "npx": "^8.1.0" },
+  "engines": {
+    "node": "^16.13.0",
+    "npm": "^8.1.0",
+    "npx": "^8.1.0"
+  },
   "main": "./index.js",
   "types": "./index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Common Markdown table-related utilities",
   "main": "./index.js",
   "types": "./index.d.ts",
+  "engines": { "node": ">=16.13.0" },
   "scripts": {
     "prepare": "npm run compile-src && npm run compile-doc",
     "compile-src": "tsc --project ./",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Common Markdown table-related utilities",
   "main": "./index.js",
   "types": "./index.d.ts",
-  "engines": { "node": ">=16.13.0" },
+  "engines": {
+    "node": ">=16.13.0"
+  },
   "scripts": {
     "prepare": "npm run compile-src && npm run compile-doc",
     "compile-src": "tsc --project ./",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,10 @@
   "name": "@openinf/util-md-table",
   "version": "1.1.3",
   "description": "Common Markdown table-related utilities",
+  "packageManager": "npm",
+  "engines": { "node": "^16.13.0", "npm": "^8.1.0", "npx": "^8.1.0" },
   "main": "./index.js",
   "types": "./index.d.ts",
-  "engines": {
-    "node": ">=16.13.0"
-  },
   "scripts": {
     "prepare": "npm run compile-src && npm run compile-doc",
     "compile-src": "tsc --project ./",


### PR DESCRIPTION
- **Begin specifying the Last Known Good Release of Node.js toolchain**

  LKGR of Node.js toolchain is 1ˢᵗ release of “Gallium” LTS (v16.13.0).

  Refs: https://github.com/nodejs/node/pull/40536#pullrequestreview-789094890

  > This release marks the transition of Node.js 16.x into Long Term
  > Support (LTS) with the codename “Gallium”. The 16.x release line
  > now moves into “Active LTS” and will remain so until October 2022.
  > After that time, it will move into “Maintenance” until end-of-life
  > in April 2024.

  Days until “Gallium” goes into “Maintenance” (October 2022): 8 weeks from now[^1]
  Days until “Gallium” goes EOL (April 2024): 86 weeks from now[^2]

  [^1]: https://www.wolframalpha.com/input?i2d=true&i=third+Tuesday+in+October+of+year+2022
  [^2]: https://www.wolframalpha.com/input?i2d=true&i=third+Tuesday+in+April+of+year+2024

  Refs: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V16.md#16.13.0

- **Begin specifying that we would like to use globally-installed npm**

  > While `npm` is a valid option in the “packageManager” property, the
  > lack of shim will cause the global npm to be used.

  Refs: https://nodejs.org/docs/v16.13.0/api/corepack.html#corepack_how_does_corepack_interact_with_npm

  > If the value corresponds to a supported package manager, Corepack
  > will make sure that all calls to the relevant binaries are run
  > against the requested version, downloading it on demand if needed,
  > and aborting if it cannot be successfully retrieved.

  Refs: https://nodejs.org/docs/v16.13.0/api/corepack.html#configuring-a-package

Signed-off-by: Derek Lewis <DerekNonGeneric@inf.is>

/cc @septs