### PR TITLE
feat(infra): inform pnpm users of our “Gallium” runtime & toolchain

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 save-exact=true
+node-version=16.13.0
+engine-strict=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 save-exact=true
-node-version=16.13.0
 engine-strict=true
+node-version=16.13.0
+npm-version=8.1.0


### PR DESCRIPTION
> If you want to prevent contributors of your project from adding new
> incompatible dependencies, use `node-version` and `engine-strict` in
> a `.npmrc` file at the root of the project.

Refs: https://pnpm.io/npmrc#node-version

This way, even if someone is using Node.js v18 runtime & toolchain,
they will not be able to install a new dependency that doesn't support
our Node.js v16.13.0 (“Gallium” runtime & toolchain).

Refs: https://github.com/openinf/util-md-table/pull/64

/cc @septs @shellscape